### PR TITLE
Add new Stripe and Paddle checkout functions

### DIFF
--- a/src/core/paymentForms/paddleForm.ts
+++ b/src/core/paymentForms/paddleForm.ts
@@ -8,27 +8,7 @@ import {setCookie} from "../../cookies";
 import {DeepLinkURL, SelectedProductDuration} from "../config/constants";
 
 class PaddleForm implements PaymentForm {
-    // Add support for both new and old element IDs
-    private readonly elementIDs = {
-        new: {
-            form: "apphud-paddle-payment-form",
-            submit: "paddle-submit",
-            error: "paddle-error-message"
-        },
-        old: {
-            form: "apphud-payment-form",
-            submit: "submit",
-            error: "error-message"
-        }
-    }
-    
-    // Add formType detection
-    private formType: 'new' | 'old' = 'new';
-    
     private paddle: Paddle | null | undefined = null
-    private submit: HTMLButtonElement | null = null
-    private submitReadyText = "Subscribe"
-    private submitProcessingText = "Please wait..."
     private currentOptions: PaymentProviderFormOptions | null = null
     private subscription: Subscription | null = null
 
@@ -77,15 +57,12 @@ class PaddleForm implements PaymentForm {
             logError('Failed to create subscription', error)
             return
         }
-        
-        // Detect which form type is present
-        this.formType = document.getElementById(this.elementIDs.new.form) ? 'new' : 'old';
-        
+
         log("Initializing Paddle payment form for product:", productId)
         this.formBuilder.emit("payment_form_initialized", { 
             paymentProvider: "paddle", 
             event: { 
-                selector: `#${this.elementIDs[this.formType].form}` 
+                selector: `#${options?.id}`
             } 
         })
 
@@ -100,66 +77,23 @@ class PaddleForm implements PaymentForm {
             return
         }
 
-        // Setup form elements
-        await this.setupFormElements()
-        
-        // Setup checkout configuration
-        await this.setupCheckout(productId, paywallId, placementId, options)
-    }
+        const settings = options?.paddleSettings || {}
 
-    private async setupFormElements(): Promise<void> {
-        const form = document.querySelector(`#${this.elementIDs[this.formType].form}`)
-        if (!form) {
-            throw new Error("Payment form container not found")
-        }
-
-        // Update submit button selector
-        const submitButton = document.querySelector(`#${this.elementIDs[this.formType].submit}`)
-        if (!submitButton) {
-            logError(`Submit button is required. Add <button id="${this.elementIDs[this.formType].submit}">Pay</button>`)
+        if (!this.currentOptions?.id) {
+            logError("Paddle form id is required")
             return
-        }
-
-        this.submit = submitButton as HTMLButtonElement
-        this.setButtonState("loading")
-
-        if (this.submit.innerText !== "") {
-            this.submitReadyText = this.submit.innerText
-        }
-
-        // Update error message container ID
-        if (!document.querySelector(`#${this.elementIDs[this.formType].error}`)) {
-            const errorDiv = document.createElement('div')
-            errorDiv.id = this.elementIDs[this.formType].error
-            form.appendChild(errorDiv)
-        }
-    }
-
-    /**
-     * Setup checkout configuration and form submission handler
-     * @param productId - paddle price_id
-     * @param paywallId - paywall user purchased from
-     * @param placementId - placement id user purchased from
-     * @param options - Form options including success URL and appearance customization
-     * @private
-     */
-    private async setupCheckout(
-        productId: string, 
-        paywallId: string | undefined, 
-        placementId: string | undefined, 
-        options: PaymentProviderFormOptions
-    ): Promise<void> {
-        const form = document.querySelector(`#${this.elementIDs[this.formType].form}`)
-
-        if (!form) {
-            throw new Error("Payment form: no form provided")
         }
 
         const baseConfig = {
             settings: {
-                displayMode: "overlay" as const,
-                theme: options?.paddleAppearance?.theme || "light",
-                locale: this.user.locale || "en"
+                locale: this.user.locale || "en",
+                displayMode: settings.displayMode || "overlay",
+                theme: settings.theme || "light",
+                variant: settings.variant,
+                frameTarget: this.currentOptions?.id,
+                frameInitialHeight: settings.frameInitialHeight,
+                frameStyle: settings.frameStyle,
+                allowedPaymentMethods: settings.allowedPaymentMethods
             },
             customData: {
                 apphud_client_id: this.user.id,
@@ -183,26 +117,22 @@ class PaddleForm implements PaymentForm {
                     quantity: 1
                 }]
             }
+        
+        this.setButtonState("processing")
 
-        form.addEventListener('submit', async (event) => {
-            event.preventDefault()
-            this.setButtonState("processing")
-
-            try {
-                if (!this.paddle) {
-                    throw new Error("Paddle not initialized")
-                }
-                await this.paddle.Checkout.open(checkoutConfig)
-            } catch (error) {
-                logError("Failed to open Paddle checkout:", error)
-                this.setButtonState("ready")
-                
-                const errorElement = document.querySelector(`#${this.elementIDs[this.formType].error}`)
-                if (errorElement) {
-                    errorElement.textContent = error instanceof Error ? error.message : "Payment failed"
-                }
+        try {
+            if (!this.paddle) {
+                throw new Error("Paddle not initialized")
             }
-        })
+            this.paddle.Checkout.open(checkoutConfig)
+        } catch (error) {
+            logError("Failed to open Paddle checkout:", error)
+            this.setButtonState("ready")
+
+            if (settings.errorCallback) {
+                settings.errorCallback(error instanceof Error ? error.message : "Payment failed")
+            }
+        }
 
         // Form is ready
         this.setButtonState("ready")
@@ -252,6 +182,9 @@ class PaddleForm implements PaymentForm {
                     event: { error: event.data }
                 })
                 this.setButtonState("ready")
+                if (this.currentOptions?.paddleSettings?.errorCallback) {
+                    this.currentOptions.paddleSettings.errorCallback(event.data)
+                }
                 break;
                 
             case "checkout.loaded":
@@ -271,23 +204,8 @@ class PaddleForm implements PaymentForm {
      * @private
      */
     private setButtonState(state: "loading" | "ready" | "processing"): void {
-        if (!this.submit) {
-            logError("Submit button not found. Failed to set state:", state)
-            return
-        }
-
-        switch (state) {
-            case "loading":
-                this.submit.setAttribute("disabled", "disabled")
-                break
-            case "ready":
-                this.submit.removeAttribute("disabled")
-                this.submit.innerText = this.submitReadyText
-                break
-            case "processing":
-                this.submit.setAttribute("disabled", "disabled")
-                this.submit.innerText = this.submitProcessingText
-                break
+        if (this.currentOptions?.buttonStateSetter) {
+            this.currentOptions.buttonStateSetter(state)
         }
     }
 

--- a/src/core/paymentForms/paddleForm.ts
+++ b/src/core/paymentForms/paddleForm.ts
@@ -1,5 +1,5 @@
 import {log, logError} from "../../utils";
-import {initializePaddle, Paddle, CheckoutOpenOptions, PaddleEventData} from '@paddle/paddle-js'
+import {initializePaddle, Paddle, CheckoutOpenOptions, PaddleEventData, DisplayMode, AvailablePaymentMethod, Variant} from '@paddle/paddle-js'
 import {PaymentForm, PaymentProviderFormOptions, User, PaymentProvider, Subscription, PaddleSubscriptionOptions} from "../../types";
 import FormBuilder from "./formBuilder";
 import {config} from "../config/config";
@@ -87,13 +87,13 @@ class PaddleForm implements PaymentForm {
         const baseConfig = {
             settings: {
                 locale: this.user.locale || "en",
-                displayMode: settings.displayMode || "overlay",
+                displayMode: (settings.displayMode || "overlay") as DisplayMode,
                 theme: settings.theme || "light",
-                variant: settings.variant,
+                variant: settings.variant as Variant,
                 frameTarget: this.currentOptions?.id,
                 frameInitialHeight: settings.frameInitialHeight,
                 frameStyle: settings.frameStyle,
-                allowedPaymentMethods: settings.allowedPaymentMethods
+                allowedPaymentMethods: settings.allowedPaymentMethods as AvailablePaymentMethod[]
             },
             customData: {
                 apphud_client_id: this.user.id,
@@ -183,7 +183,9 @@ class PaddleForm implements PaymentForm {
                 })
                 this.setButtonState("ready")
                 if (this.currentOptions?.paddleSettings?.errorCallback) {
-                    this.currentOptions.paddleSettings.errorCallback(event.data)
+                    this.currentOptions.paddleSettings.errorCallback(
+                        typeof event.data === "string" ? event.data : "Payment failed"
+                    )
                 }
                 break;
                 

--- a/src/core/paymentForms/stripeForm.ts
+++ b/src/core/paymentForms/stripeForm.ts
@@ -107,11 +107,11 @@ class StripeForm implements PaymentForm {
         this.buttonStateSetter = options.buttonStateSetter
 
         // Detect which form type is present
-        if (options.elementID) {
+        if (options.id) {
             this.elementIDs = {}
 
             for (const key in ELEMENT_IDS.new) {
-                this.elementIDs[key] = `${options.elementID}-${ELEMENT_IDS.new[key]}`
+                this.elementIDs[key] = `${options.id}-${ELEMENT_IDS.new[key]}`
             }
         } else if (document.getElementById(ELEMENT_IDS.new.form)) {
             this.elementIDs = ELEMENT_IDS.new

--- a/src/core/paymentForms/stripeForm.ts
+++ b/src/core/paymentForms/stripeForm.ts
@@ -111,7 +111,7 @@ class StripeForm implements PaymentForm {
             this.elementIDs = {}
 
             for (const key in ELEMENT_IDS.new) {
-                this.elementIDs[key] = `${options.id}-${ELEMENT_IDS.new[key]}`
+                this.elementIDs[key] = `${options.id}-${ELEMENT_IDS.new[key as keyof typeof ELEMENT_IDS.new]}`
             }
         } else if (document.getElementById(ELEMENT_IDS.new.form)) {
             this.elementIDs = ELEMENT_IDS.new

--- a/src/core/paymentForms/stripeForm.ts
+++ b/src/core/paymentForms/stripeForm.ts
@@ -17,24 +17,22 @@ import {setCookie} from "../../cookies";
 import {config} from "../config/config";
 import FormBuilder from "./formBuilder";
 
-class StripeForm implements PaymentForm {
-    private readonly elementIDs = {
-        new: {
-            form: "apphud-stripe-payment-form",
-            payment: "stripe-payment-element",
-            submit: "stripe-submit",
-            error: "stripe-error-message"
-        },
-        old: {
-            form: "apphud-payment-form",
-            payment: "payment-element",
-            submit: "submit",
-            error: "error-message"
-        }
+const ELEMENT_IDS = {
+    new: {
+        form: "apphud-stripe-payment-form",
+        payment: "stripe-payment-element",
+        submit: "stripe-submit",
+        error: "stripe-error-message"
+    },
+    old: {
+        form: "apphud-payment-form",
+        payment: "payment-element",
+        submit: "submit",
+        error: "error-message"
     }
-    
-    private formType: 'new' | 'old' = 'new';
-    
+}
+
+class StripeForm implements PaymentForm {
     private stripe: Stripe | null = null
     private elements: StripeElements | undefined = undefined
     private paymentElement: StripePaymentElement | null = null
@@ -47,6 +45,7 @@ class StripeForm implements PaymentForm {
     private currentPaywallId: string | undefined;
     private currentPlacementId: string | undefined;
     private subscriptionOptions?: StripeSubscriptionOptions;
+    private elementIDs: { [key: string]: string } = ELEMENT_IDS.old;
 
     constructor(private user: User, private providerId: string, private accountId: string, private formBuilder: FormBuilder) {
         documentReady(async () => {
@@ -72,8 +71,8 @@ class StripeForm implements PaymentForm {
                 padding: 10px 0;
             }
 
-            #${this.elementIDs.new.payment},
-            #${this.elementIDs.old.payment} {
+            #${ELEMENT_IDS.new.payment},
+            #${ELEMENT_IDS.old.payment} {
                 width: 100%;
             }
         `;
@@ -106,12 +105,20 @@ class StripeForm implements PaymentForm {
         this.formBuilder.emit("payment_form_initialized", { paymentProvider: "stripe", event: { selector: "#apphud-stripe-payment-form" } })
 
         // Detect which form type is present
-        this.formType = document.getElementById(this.elementIDs.new.form) ? 'new' : 'old';
+        if (options.elementID) {
+            this.elementIDs = {}
+
+            for (const key in ELEMENT_IDS.new) {
+                this.elementIDs[key] = `${options.elementID}-${ELEMENT_IDS.new[key]}`
+            }
+        } else if (document.getElementById(ELEMENT_IDS.new.form)) {
+            this.elementIDs = ELEMENT_IDS.new
+        }
         
-        const submitButton = document.querySelector(`#${this.elementIDs[this.formType].submit}`)
+        const submitButton = document.querySelector(`#${this.elementIDs.submit}`)
 
         if (!submitButton) {
-            logError(`Submit button is required. Add <button id="${this.elementIDs[this.formType].submit}">Pay</button>`)
+            logError(`Submit button is required. Add <button id="${this.elementIDs.submit}">Pay</button>`)
             return
         }
 
@@ -138,7 +145,7 @@ class StripeForm implements PaymentForm {
             logError("Failed to initialize Stripe form:", error)
             this.setButtonState("ready")
             
-            const errorElement = document.querySelector(`#${this.elementIDs[this.formType].error}`)
+            const errorElement = document.querySelector(`#${this.elementIDs.error}`)
             if (errorElement) {
                 errorElement.textContent = "Failed to initialize payment form. Please try again."
             }
@@ -242,6 +249,9 @@ class StripeForm implements PaymentForm {
         const stripeAppearance = options?.stripeAppearance && {
             theme: options.stripeAppearance.theme,
             variables: options.stripeAppearance.variables,
+            rules: options.stripeAppearance.rules,
+            disableAnimations: options.stripeAppearance.disableAnimations,
+            labels: options.stripeAppearance.labels,
         }
 
         // Define elements options
@@ -254,12 +264,14 @@ class StripeForm implements PaymentForm {
         this.elements = this.stripe.elements(elementsOptions)
         
         // Create and mount the Payment Element
-        const paymentElement = this.elements.create('payment')
+        const paymentElement = this.elements.create('payment', {
+            layout: options?.stripeAppearance?.layout
+        })
         
-        const paymentElementContainer = document.getElementById(this.elementIDs[this.formType].payment);
+        const paymentElementContainer = document.getElementById(this.elementIDs.payment);
         if (paymentElementContainer) {
             paymentElementContainer.innerHTML = '<div class="stripe-element-container"></div>';
-            paymentElement.mount(`#${this.elementIDs[this.formType].payment} .stripe-element-container`);
+            paymentElement.mount(`#${this.elementIDs.payment} .stripe-element-container`);
         }
 
         this.paymentElement = paymentElement;
@@ -272,7 +284,7 @@ class StripeForm implements PaymentForm {
 
         // Event listener for change events
         paymentElement.on('change', (event: StripePaymentElementChangeEvent) => {
-            const displayError = document.querySelector(`#${this.elementIDs[this.formType].error}`)
+            const displayError = document.querySelector(`#${this.elementIDs.error}`)
             if (displayError) {
                 // Clear any previous error messages when the form is valid
                 if (event.complete) {
@@ -283,7 +295,7 @@ class StripeForm implements PaymentForm {
 
         // Add a separate error event listener for loader errors
         paymentElement.on('loaderror', (event) => {
-            const displayError = document.querySelector(`#${this.elementIDs[this.formType].error}`)
+            const displayError = document.querySelector(`#${this.elementIDs.error}`)
             if (displayError && event.error) {
                 displayError.textContent = event.error.message || null;
             }
@@ -296,7 +308,7 @@ class StripeForm implements PaymentForm {
      * @private
      */
     private async setupForm(options?: PaymentProviderFormOptions): Promise<void> {
-        const form = document.querySelector(`#${this.elementIDs[this.formType].form}`)
+        const form = document.querySelector(`#${this.elementIDs.form}`)
 
         if (!form) {
             logError("Payment form: no form provided")
@@ -364,7 +376,7 @@ class StripeForm implements PaymentForm {
                 logError("Failed to process payment:", error)
                 this.setButtonState("ready")
                 
-                const errorElement = document.querySelector(`#${this.elementIDs[this.formType].error}`)
+                const errorElement = document.querySelector(`#${this.elementIDs.error}`)
                 if (errorElement) {
                     errorElement.textContent = error instanceof Error ? error.message : "Failed to process payment. Please try again."
                 }

--- a/src/core/paymentForms/stripeForm.ts
+++ b/src/core/paymentForms/stripeForm.ts
@@ -46,6 +46,7 @@ class StripeForm implements PaymentForm {
     private currentPlacementId: string | undefined;
     private subscriptionOptions?: StripeSubscriptionOptions;
     private elementIDs: { [key: string]: string } = ELEMENT_IDS.old;
+    private buttonStateSetter?: (state: "loading" | "ready" | "processing") => void | undefined;
 
     constructor(private user: User, private providerId: string, private accountId: string, private formBuilder: FormBuilder) {
         documentReady(async () => {
@@ -103,6 +104,7 @@ class StripeForm implements PaymentForm {
         this.currentPlacementId = placementId;
         this.subscriptionOptions = subscriptionOptions;
         this.formBuilder.emit("payment_form_initialized", { paymentProvider: "stripe", event: { selector: "#apphud-stripe-payment-form" } })
+        this.buttonStateSetter = options.buttonStateSetter
 
         // Detect which form type is present
         if (options.elementID) {
@@ -160,6 +162,11 @@ class StripeForm implements PaymentForm {
     private setButtonState(state: "loading" | "ready" | "processing"): void {
         if (!this.submit) {
             logError("Submit button not found. Failed to set state:", state)
+            return
+        }
+
+        if (this.buttonStateSetter) {
+            this.buttonStateSetter(state)
             return
         }
 

--- a/src/types/paymentForm.ts
+++ b/src/types/paymentForm.ts
@@ -29,6 +29,7 @@ export interface PaymentProviderFormOptions {
     failureUrl?: string
     stripeAppearance?: StripeAppearanceOptions
     paddleAppearance?: PaddleAppearanceOptions
+    elementID?: string
 }
 
 export interface Country {
@@ -47,6 +48,9 @@ export interface StripeAppearanceOptions {
     theme?: Appearance['theme'];
     variables?: Appearance['variables'];
     layout?: Layout
+    rules?: Appearance['rules']
+    disableAnimations?: boolean
+    labels?: Appearance['labels']
 }
 
 export interface PaddleAppearanceOptions {

--- a/src/types/paymentForm.ts
+++ b/src/types/paymentForm.ts
@@ -28,8 +28,8 @@ export interface PaymentProviderFormOptions {
     successUrl?: string
     failureUrl?: string
     stripeAppearance?: StripeAppearanceOptions
-    paddleAppearance?: PaddleAppearanceOptions
-    elementID?: string
+    paddleSettings?: PaddleSettingsOptions
+    id?: string
     buttonStateSetter?: (state: "loading" | "ready" | "processing") => void
 }
 
@@ -54,8 +54,14 @@ export interface StripeAppearanceOptions {
     labels?: Appearance['labels']
 }
 
-export interface PaddleAppearanceOptions {
-  theme?: 'light' | 'dark';
+export interface PaddleSettingsOptions {
+    variant?: string;
+    frameInitialHeight?: number;
+    frameStyle?: string;
+    displayMode?: string;
+    allowedPaymentMethods?: string[];
+    theme?: 'light' | 'dark';
+    errorCallback?: (error: string) => void;
 }
 
 export interface SubscriptionOptions {

--- a/src/types/paymentForm.ts
+++ b/src/types/paymentForm.ts
@@ -30,6 +30,7 @@ export interface PaymentProviderFormOptions {
     stripeAppearance?: StripeAppearanceOptions
     paddleAppearance?: PaddleAppearanceOptions
     elementID?: string
+    buttonStateSetter?: (state: "loading" | "ready" | "processing") => void
 }
 
 export interface Country {


### PR DESCRIPTION
SDK changes for the new customizable Stripe and Paddle checkout components.

Changes:
- Added an ID to Stripe forms so you can have multiple forms on the same page.
- Added support for more Stripe elements and Paddle embed customization options.
- Added a button state setter function to let the Stripe form component manage it's own button state.
- Removed the submit button, form element and error element requirements from the Paddle form because Paddle embeds include a submit button, and the Framer component can manage the error label itself.

These changes are backwards compatible, so they shouldn't break any existing forms that use Stripe.