### PR TITLE
Add onSuccess callback to payment forms

### DIFF
--- a/src/core/paymentForms/paddleForm.ts
+++ b/src/core/paymentForms/paddleForm.ts
@@ -167,10 +167,12 @@ class PaddleForm implements PaymentForm {
                 })
 
                 setTimeout(() => {
-                    if (options?.successUrl && options.successUrl !== 'undefined') {
+                    if (options?.onSuccess) {
+                        options.onSuccess()
+                    } else if (options?.successUrl && options.successUrl !== 'undefined') {
                         document.location.href = options?.successUrl
                     } else {
-                        document.location.href = config.baseSuccessURL+'/'+deepLink
+                        document.location.href = config.baseSuccessURL + '/' + deepLink
                     }
                 }, config.redirectDelay)
                 break;

--- a/src/core/paymentForms/stripeForm.ts
+++ b/src/core/paymentForms/stripeForm.ts
@@ -378,7 +378,9 @@ class StripeForm implements PaymentForm {
                 }
 
                 setTimeout(() => {
-                    if (options?.successUrl && options.successUrl !== 'undefined') {
+                    if (options?.onSuccess) {
+                        options.onSuccess()
+                    } else if (options?.successUrl && options.successUrl !== 'undefined') {
                         document.location.href = options.successUrl;
                     } else {
                         document.location.href = config.baseSuccessURL + '/' + deepLink;

--- a/src/types/paymentForm.ts
+++ b/src/types/paymentForm.ts
@@ -27,6 +27,7 @@ export interface PaymentProviderFormOptions {
     paymentProvider?: PaymentProviderKind;
     successUrl?: string
     failureUrl?: string
+    onSuccess?: () => void
     stripeAppearance?: StripeAppearanceOptions
     stripePaymentMethods?: string[]
     paddleSettings?: PaddleSettingsOptions


### PR DESCRIPTION
Adds SDK support for the success redirect option on Stripe and Paddle checkout forms.

<img width="310" alt="image" src="https://github.com/user-attachments/assets/2671393f-3980-47fe-9929-5b8301ed70b7" />

Component updates: https://github.com/apphud/Flows-Builder-Kit/commit/1b3b454ee77d665221b3ba7f4be7a77245cfccc8